### PR TITLE
Add release test to workflow

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -37,6 +37,8 @@ jobs:
       run: make test
     - name: Property-Based Tests
       run: make proper
+    - name: Release Test
+      run: make reltest
     - name: System Tests
       run: make systests
     - name: Coverage


### PR DESCRIPTION
The release test is the only place where the Erlang client was used and was missing in the workflow. Added to make sure that the client rename still works in #483.